### PR TITLE
Update to satellite 6.4 test drive

### DIFF
--- a/labs/Satellite_64_Test_Drive/satellite_64_test_drive.adoc
+++ b/labs/Satellite_64_Test_Drive/satellite_64_test_drive.adoc
@@ -422,8 +422,8 @@ By default, Satellite & Satellite Capsules require the administrator to approve 
 . Navigate to *Hosts -> All Hosts*
 . Verify that the rhaiclient is connected to the correct hostgroup which is *bootstrap*
 . Click on the host *rhaiclient.example.com* which takes you to the host details page.
-. Click the *Content* button.
-. Verify that your host is subscribed which is indicated by *Fully entitled* in the *Subscription Status* field.
+. Click the *Properties* button.
+. Verify that your host is subscribed which is indicated by *Fully entitled* in the *Subscription* field.
 
 
 === Populate risks on registered client


### PR DESCRIPTION
Following the instructions directly leads you to the host configuration menu, where the appropriate tabs are 'Properties' and the field listing the 'Fully Entitled' status is 'subscription' and not 'subscription status'